### PR TITLE
 indentation issue with state.py removed the return statement from in…

### DIFF
--- a/models/state.py
+++ b/models/state.py
@@ -27,4 +27,4 @@ class State(BaseModel, Base):
             for city_obj in models.storage.all(City).values():
                 if city_obj.state_id == self.id:
                     city_instances.append(city_obj)
-                    return city_instances
+            return city_instances


### PR DESCRIPTION
…side the loop to ensure it's outside the loop, so that all city instances related to the state can be collected before returning